### PR TITLE
docs: convert all documentation to English, generalize architecture

### DIFF
--- a/.agent/workflows/pr.md
+++ b/.agent/workflows/pr.md
@@ -1,0 +1,41 @@
+---
+description: How to create a feature branch and pull request for clab-ai-orchestrator
+---
+
+# PR Workflow for clab-ai-orchestrator
+
+## Steps
+
+// turbo-all
+
+1. Create a feature branch from main:
+```bash
+cd /Users/nkchan/clab-ai-orchestrator
+git checkout main
+git pull origin main
+git checkout -b feature/<branch-name>
+```
+
+2. Make changes and commit:
+```bash
+git add -A
+git commit -m "<type>: <description>"
+```
+Commit types: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`
+
+3. Push the feature branch:
+```bash
+git push -u origin feature/<branch-name>
+```
+
+4. Create a pull request:
+```bash
+gh pr create --title "<type>: <description>" --body "<details>"
+```
+
+5. After PR is merged, clean up:
+```bash
+git checkout main
+git pull origin main
+git branch -d feature/<branch-name>
+```

--- a/README.md
+++ b/README.md
@@ -1,75 +1,70 @@
 # 🌐 Clab AI Orchestrator
 
-AIエージェントによるネットワーク検証自動化プラットフォーム。  
-[containerlab](https://containerlab.dev/) + FRRouting + vJunos-router を使用したハイブリッドネットワークラボを、MCP（Model Context Protocol）サーバ経由でAIから操作します。
+An AI-powered network lab automation platform.  
+Operate any [containerlab](https://containerlab.dev/) topology through MCP (Model Context Protocol) — deploy, verify, troubleshoot, and document, all driven by AI.
 
-## 🏗 アーキテクチャ
+## 🏗 Architecture
 
 ```mermaid
 graph TB
     subgraph "AI Layer"
-        AI["AI Agent<br/>(Open WebUI)"]
+        AI["AI Agent<br/>(Open WebUI / LLM Client)"]
     end
 
     subgraph "MCP Layer"
         MCP["mcp-bridge<br/>(Python / STDIO)"]
+        TOOLS["Vendor Tools<br/>FRR · Junos · ..."]
+        MCP --> TOOLS
     end
 
     subgraph "Infrastructure Layer"
         CLAB["containerlab"]
-        FRR["FRR<br/>(AS65001)"]
-        VJUNOS["vJunos-router<br/>(AS65002)"]
-
-        CLAB --> FRR
-        CLAB --> VJUNOS
-        FRR --- |"P2P BGP"| VJUNOS
+        TOPO["Any Topology<br/>(multi-vendor, multi-protocol)"]
+        CLAB --> TOPO
     end
 
     AI --> MCP
-    MCP --> CLAB
-    MCP --> FRR
-    MCP --> VJUNOS
+    TOOLS --> CLAB
 ```
 
-## ⚡ クイックスタート
+## ⚡ Quick Start
 
-### 前提条件
+### Prerequisites
 
 - Ubuntu 24.04
-- sudo 権限
-- vJunos-router QCOW2 イメージ（[Juniper](https://www.juniper.net/) からダウンロード）
+- sudo privileges
+- NOS images (e.g., vJunos-router QCOW2 from [Juniper](https://www.juniper.net/))
 
-### 1. セットアップ
+### 1. Setup
 
 ```bash
-# リポジトリをクローン
 git clone https://github.com/<your-org>/clab-ai-orchestrator.git
 cd clab-ai-orchestrator
 
-# vJunos イメージを配置
+# Place NOS images
 cp /path/to/vJunos-router-25.4R1.12.qcow2 images/
 
-# セットアップスクリプトを実行
+# Run setup script
 sudo bash setup/install.sh
 ```
 
-### 2. ラボをデプロイ
+### 2. Deploy a Lab
 
 ```bash
 sudo clab deploy -t labs/basic-bgp/topology.clab.yml
 ```
 
-### 3. 疎通確認
+### 3. Verify
 
 ```bash
-# FRR の BGP 状態
+# FRR BGP status
 docker exec clab-basic-bgp-frr1 vtysh -c "show ip bgp summary"
 
-# vJunos の BGP 状態
+# vJunos BGP status
 docker exec clab-basic-bgp-vjunos1 cli show bgp summary
 ```
 
-### 4. MCP Bridge を起動
+### 4. Start MCP Bridge
 
 ```bash
 cd mcp-bridge
@@ -77,42 +72,52 @@ pip install -e .
 mcp-bridge  # STDIO mode
 ```
 
-## 📂 プロジェクト構造
+Or run in Docker:
+
+```bash
+docker compose up -d
+```
+
+## 📂 Project Structure
 
 ```
-├── agent.md              # AI エージェント定義
-├── setup/                # セットアップスクリプト
-├── labs/                 # containerlab トポロジ定義
-│   └── basic-bgp/        # FRR + vJunos P2P BGP ラボ
-├── mcp-bridge/           # MCP サーバ (Python)
+├── agent.md              # AI agent definition
+├── setup/                # Setup scripts
+├── labs/                 # Containerlab topology definitions
+│   └── basic-bgp/        # FRR + vJunos P2P BGP lab
+├── mcp-bridge/           # MCP server (Python)
 │   └── src/mcp_bridge/
-│       ├── server.py      # メインサーバ
-│       └── tools/         # clab / frr / junos ツール
-├── vendors/              # ベンダー別パーサ・テンプレート
+│       ├── server.py      # Main server
+│       └── tools/         # clab / frr / junos tools
+├── vendors/              # Vendor-specific parsers & templates
 │   ├── frr/
 │   └── junos/
-├── images/               # VM イメージ (git管理外)
-└── docs/                 # ドキュメント
+├── samples/              # Usage examples & scenarios
+├── images/               # VM images (git-ignored)
+└── docs/                 # Documentation
 ```
 
-## 🔧 MCP ツール一覧
+## 🔧 MCP Tools
 
-| ツール | 説明 |
-|--------|------|
-| `clab_deploy` | containerlab トポロジをデプロイ |
-| `clab_destroy` | トポロジを破棄 |
-| `clab_inspect` | ノード状態を確認 |
-| `frr_show` | FRR で show コマンドを実行 |
-| `frr_config` | FRR に設定を投入 |
-| `junos_show` | vJunos で show コマンドを実行 |
-| `junos_config` | vJunos に設定を投入 |
+| Tool | Description |
+|------|-------------|
+| `clab_deploy` | Deploy a containerlab topology |
+| `clab_destroy` | Destroy a topology |
+| `clab_inspect` | Inspect node status |
+| `frr_show` | Execute show commands on FRR nodes |
+| `frr_config` | Push configuration to FRR nodes |
+| `junos_show` | Execute show commands on vJunos nodes |
+| `junos_config` | Push configuration to vJunos nodes |
 
-## 📚 ドキュメント
+## 📚 Documentation
 
-- [セットアップガイド](docs/setup-guide.md) - 詳細インストール手順
-- [アーキテクチャ](docs/architecture.md) - 設計思想と構成
-- [トラブルシューティング](docs/troubleshooting.md) - よくある問題と対処法
+- [Setup Guide](docs/setup-guide.md) — Detailed installation steps
+- [Architecture](docs/architecture.md) — Design and component overview
+- [Repository Structure](docs/repository-structure.md) — Directory layout explained
+- [Roadmap](docs/roadmap.md) — Project roadmap
+- [Version Strategy](docs/version-strategy.md) — Dependency pinning policy
+- [Troubleshooting](docs/troubleshooting.md) — Common issues and fixes
 
-## 📄 ライセンス
+## 📄 License
 
 MIT License

--- a/agent.md
+++ b/agent.md
@@ -1,52 +1,52 @@
 # AGENT.md: Network Automation & Verification Agent (ClabAgent)
 
-あなたは、**containerlab**、**FRRouting (FRR)**、および **Juniper (vJunos-router)** に精通した、シニアネットワークオートメーションエンジニアです。
-ローカルおよびリモートサーバにまたがる分散検証環境において、構築・テスト・トラブルシューティングを自律的に遂行します。
-また、本プロジェクトは **github.com でパブリックに公開される OSS** であることを強く意識し、誰もが利用・貢献できる品質を維持します。
+You are a senior network automation engineer, proficient in **containerlab**, **FRRouting (FRR)**, and **Juniper (vJunos-router)**.
+You autonomously build, test, and troubleshoot distributed lab environments spanning local and remote servers.
+This project is **publicly released as OSS on github.com** — always maintain quality that enables anyone to use and contribute.
 
-## 🎯 究極の目標 (Core Objectives)
-1. **ハイブリッド環境の構築**: FRRとvJunos-routerが混在する複雑なトポロジを、正確にデプロイし初期設定を行う。
-2. **AI駆動型トラブルシューティング**: 疎通不可やBGPネイバー異常に対し、自らログを収集・解析し、根本原因を特定して修正案を提示する。
-3. **手順の論理検証**: 人間が作成した作業手順書を実機ステータスと比較し、矛盾や考慮漏れを事前に指摘する。
-4. **エビデンスの自動生成**: 検証結果をMermaid図解やMarkdownレポートとして出力し、ドキュメント作成の工数を削減する。
-5. **OSSドキュメントの整備**: 他のNWエンジニアが再現できるよう、`docs/` や `README.md` を常に最新かつ分かりやすく保つ。
+## 🎯 Core Objectives
+1. **Hybrid Environment Deployment**: Accurately deploy and configure complex topologies mixing FRR and vJunos-router.
+2. **AI-Driven Troubleshooting**: Autonomously collect and analyze logs for connectivity issues and BGP neighbor anomalies, identify root causes, and propose fixes.
+3. **Runbook Validation**: Compare human-authored operational runbooks against live device state, proactively identifying contradictions and oversights.
+4. **Automated Evidence Generation**: Output verification results as Mermaid diagrams and Markdown reports, reducing documentation effort.
+5. **OSS Documentation**: Keep `docs/` and `README.md` up-to-date and clear so other network engineers can reproduce the environment.
 
-## 🛠 技術スタック & コンテキスト
+## 🛠 Tech Stack & Context
 - **Infrastructure**: containerlab (clab)
 - **Targets**: FRRouting (vtysh), Juniper vJunos-router (CLI / NETCONF)
 - **Interface**: MCP (Model Context Protocol)
-  - **既存MCPの活用**: `docker-mcp`（コンテナ操作）, `ssh-mcp`（リモートサーバ操作）
-  - **自作MCP (`mcp-bridge`)**: ベンダー固有のロジックと既存MCPを仲介する。
+  - **Existing MCPs**: `docker-mcp` (container operations), `ssh-mcp` (remote server operations)
+  - **Custom MCP (`mcp-bridge`)**: Mediates between vendor-specific logic and existing MCPs.
 
-## 📂 リポジトリ構造の理解
-- `mcp-bridge/`: あなたが外部と通信するためのカスタムMCPサーバ。
-- `vendors/`: `junos/` や `frr/` ごとのパーサやテンプレート。
-- `labs/`: containerlabのYAML定義と初期設定。
-- `docs/`: ユーザーガイド、トラブルシューティングガイド、設計思想。
+## 📂 Repository Structure
+- `mcp-bridge/`: Custom MCP server for external communication.
+- `vendors/`: Per-vendor (`junos/`, `frr/`) parsers and templates.
+- `labs/`: Containerlab YAML definitions and initial configs.
+- `docs/`: User guides, troubleshooting guides, design documentation.
 
-## 📝 動作ガイドライン (Operating Rules)
-### 1. 状態把握の優先 (State-First)
-変更の前後は必ず `clab inspect` 等で環境の「真実」を確認せよ。
+## 📝 Operating Rules
+### 1. State-First
+Always verify the environment's "ground truth" via `clab inspect` etc. before and after changes.
 
-### 2. 公開を意識したドキュメンテーション (Docs-as-Code)
-- 新しいツールやラボ構成を作成した際は、必ず `docs/` 内に関連ドキュメントを作成、または更新せよ。
-- READMEは「導入のしやすさ」を最優先し、前提条件やセットアップ手順を明確に記述せよ。
+### 2. Docs-as-Code
+- When creating new tools or lab configs, always create or update related documentation in `docs/`.
+- README prioritizes "ease of adoption" — clearly document prerequisites and setup steps.
 
-### 3. ベンダー固有の作法
-- **FRR**: `vtysh` および Linuxカーネルコマンドを駆使せよ。
-- **Junos**: 構造化データ（JSON: `| display json`）を優先的に活用せよ。
+### 3. Vendor-Specific Conventions
+- **FRR**: Use `vtysh` and Linux kernel commands.
+- **Junos**: Prefer structured data (JSON via `| display json`).
 
-### 4. 分散環境と検証の徹底
-リモート実行であることを意識し、全ての操作後に必ず `Reflect & Verify`（自己検証）を行え。
+### 4. Distributed Environment & Verification
+Always be aware of remote execution and perform `Reflect & Verify` (self-validation) after every operation.
 
-## 🚦 ワークフロー・パターン
-- **[Plan]**: 変更内容と影響範囲をリストアップする。
-- **[Act]**: MCPを使用して操作を実行する。
-- **[Reflect]**: ログから推論し、異常がないか論理的に判断する。
-- **[Document]**: 実施内容と結果をドキュメントに記録し、リポジトリの透明性を高める。
+## 🚦 Workflow Patterns
+- **[Plan]**: List changes and their impact scope.
+- **[Act]**: Execute operations via MCP.
+- **[Reflect]**: Reason from logs and logically determine if anomalies exist.
+- **[Document]**: Record actions and results in documentation to maintain repository transparency.
 
 ---
 
-## ⚠️ 禁止事項
-- ユーザーの許可なく `clab destroy` を実行しない。
-- 秘密情報（パスワードや特定のIP等）がドキュメントやコードにハードコードされないよう厳重に注意せよ。
+## ⚠️ Prohibited Actions
+- Never execute `clab destroy` without user permission.
+- Never hardcode secrets (passwords, specific IPs, etc.) in documentation or code.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
-# アーキテクチャ
+# Architecture
 
-## 全体構成
+## Overview
 
 ```mermaid
 graph TB
@@ -20,8 +20,8 @@ graph TB
     end
 
     subgraph "containerlab"
-        FRR1["FRR1<br/>AS65001"]
-        VJUNOS1["vJunos1<br/>AS65002"]
+        FRR1["FRR"]
+        VJUNOS1["vJunos"]
         FRR1 ---|"eBGP"| VJUNOS1
     end
 
@@ -33,27 +33,27 @@ graph TB
     JUNOS_TOOL --> |"docker exec cli"| VJUNOS1
 ```
 
-## コンポーネント
+## Components
 
 ### mcp-bridge
-- **役割**: AI エージェントとネットワーク機器の仲介
-- **通信方式**: STDIO (将来 HTTP+SSE 追加可能)
-- **言語**: Python (mcp SDK)
-- **ツール**: containerlab 操作、FRR 操作、Junos 操作
+- **Role**: Mediates between AI agents and network devices
+- **Transport**: STDIO (HTTP+SSE can be added later)
+- **Language**: Python (mcp SDK)
+- **Tools**: containerlab operations, FRR operations, Junos operations
 
 ### vendors/
-- **役割**: ベンダー固有の出力パーサと設定テンプレート
-- **FRR**: vtysh 出力の正規表現パーサ
-- **Junos**: text / JSON 両対応パーサ
-- **テンプレート**: Jinja2 形式の設定テンプレート
+- **Role**: Vendor-specific output parsers and configuration templates
+- **FRR**: Regex-based parsers for vtysh output
+- **Junos**: Parsers supporting both text and JSON (`| display json`)
+- **Templates**: Jinja2-format configuration templates
 
 ### labs/
-- **役割**: containerlab トポロジ定義と初期コンフィグ
-- **basic-bgp**: FRR + vJunos の最小 eBGP 構成
+- **Role**: Containerlab topology definitions and initial configs
+- **basic-bgp**: Minimal eBGP topology with FRR + vJunos
 
-## 設計方針
+## Design Principles
 
-1. **State-First**: 変更前後で必ず状態を確認
-2. **Docs-as-Code**: コードとドキュメントを同期
-3. **ベンダー抽象化**: vendors/ でベンダー固有ロジックを分離し、新OS追加を容易に
-4. **安全性**: show コマンドのみ frr_show/junos_show で許可、設定変更は明示的なツールを使用
+1. **State-First**: Always verify state before and after changes
+2. **Docs-as-Code**: Keep code and documentation in sync
+3. **Vendor Abstraction**: Isolate vendor-specific logic in `vendors/` for easy NOS additions
+4. **Safety**: Only `show` commands via `*_show` tools; config changes require explicit `*_config` tools

--- a/docs/repository-structure.md
+++ b/docs/repository-structure.md
@@ -1,77 +1,78 @@
-# リポジトリ構造
+# Repository Structure
 
-本プロジェクトのディレクトリ構成と、各コンポーネントの役割を解説します。
+Project directory layout and component responsibilities.
 
-## ディレクトリツリー
+## Directory Tree
 
 ```
 clab-ai-orchestrator/
 │
-├── agent.md                 # AI エージェント定義（行動規範・技術コンテキスト）
-├── README.md                # プロジェクト概要・クイックスタート
-├── docker-compose.yml       # mcp-bridge コンテナ管理
-├── .env.example             # 環境変数テンプレート
-├── .gitignore               # Git 除外設定
+├── agent.md                 # AI agent definition (behavior, tech context)
+├── README.md                # Project overview & quick start
+├── docker-compose.yml       # mcp-bridge container management
+├── .env.example             # Environment variable template
+├── .gitignore               # Git exclusions
 │
-├── setup/                   # 🔧 環境構築
-│   └── install.sh           #   Ubuntu 24.04 自動セットアップスクリプト
-│                            #   Docker, containerlab, vrnetlab, FRR を一括インストール
+├── setup/                   # 🔧 Environment Setup
+│   └── install.sh           #   Ubuntu 24.04 automated setup script
+│                            #   Installs Docker, containerlab, vrnetlab, FRR
 │
-├── images/                  # 📦 VM イメージ格納 (git管理外)
-│   └── .gitkeep             #   ディレクトリ構造のみ管理
-│                            #   ここに vJunos-router-*.qcow2 を配置する
+├── images/                  # 📦 VM Images (git-ignored)
+│   └── .gitkeep             #   Only directory structure is tracked
+│                            #   Place vJunos-router-*.qcow2 here
 │
-├── labs/                    # 🌐 containerlab トポロジ定義
-│   ├── README.md            #   ラボ一覧と使い方
-│   └── basic-bgp/           #   基本 eBGP ラボ (FRR + vJunos)
+├── labs/                    # 🌐 Containerlab Topology Definitions
+│   ├── README.md            #   Lab index
+│   └── basic-bgp/           #   Basic eBGP lab (FRR + vJunos)
 │       ├── topology.clab.yml
-│       └── configs/         #   ノード別初期コンフィグ
+│       └── configs/         #   Per-node initial configs
 │           ├── frr1/
 │           └── vjunos1/
 │
-├── samples/                 # 📝 使用例・シナリオ
-│   ├── README.md            #   サンプル一覧
-│   ├── 01_deploy_and_verify/ #  ラボデプロイ→BGP確認の基本フロー
-│   ├── 02_troubleshoot_bgp/ #   BGP障害の調査・修復シナリオ
-│   └── 03_config_change/    #   設定変更・ロールバックのシナリオ
+├── samples/                 # 📝 Usage Examples & Scenarios
+│   ├── README.md            #   Scenario index
+│   ├── 01_deploy_and_verify/ #  Lab deploy → BGP verification flow
+│   ├── 02_troubleshoot_bgp/ #   BGP fault investigation & repair
+│   └── 03_config_change/    #   Config change & rollback
 │
-├── mcp-bridge/              # 🐍 MCP サーバ (Python)
-│   ├── Dockerfile           #   コンテナイメージ定義
-│   ├── pyproject.toml       #   パッケージ定義
-│   ├── requirements.lock    #   依存バージョン完全固定
+├── mcp-bridge/              # 🐍 MCP Server (Python)
+│   ├── Dockerfile           #   Container image definition
+│   ├── pyproject.toml       #   Package definition
+│   ├── requirements.lock    #   Fully pinned dependencies
 │   ├── README.md
 │   └── src/mcp_bridge/
-│       ├── server.py        #   MCP サーバ本体 (STDIO)
-│       ├── tools/           #   MCP ツール実装
-│       │   ├── clab.py      #     containerlab 操作
-│       │   ├── frr.py       #     FRR vtysh 操作
-│       │   └── junos.py     #     vJunos CLI 操作
+│       ├── server.py        #   MCP server entry point (STDIO)
+│       ├── tools/           #   MCP tool implementations
+│       │   ├── clab.py      #     containerlab operations
+│       │   ├── frr.py       #     FRR vtysh operations
+│       │   └── junos.py     #     vJunos CLI operations
 │       └── utils/
-│           └── docker.py    #     Docker コンテナ実行ヘルパー
+│           └── docker.py    #     Docker exec helper
 │
-├── vendors/                 # 📊 ベンダー別モジュール
+├── vendors/                 # 📊 Vendor Modules
 │   ├── README.md
 │   ├── frr/
-│   │   ├── parser.py        #   FRR 出力パーサ (BGP summary, IP route)
-│   │   └── templates/       #   Jinja2 設定テンプレート
+│   │   ├── parser.py        #   FRR output parser (BGP summary, IP route)
+│   │   └── templates/       #   Jinja2 config templates
 │   └── junos/
-│       ├── parser.py        #   Junos 出力パーサ (text/JSON)
-│       └── templates/       #   Jinja2 設定テンプレート
+│       ├── parser.py        #   Junos output parser (text/JSON)
+│       └── templates/       #   Jinja2 config templates
 │
-└── docs/                    # 📚 ドキュメント
-    ├── repository-structure.md  # ← このファイル
-    ├── setup-guide.md           # 詳細セットアップ手順
-    ├── architecture.md          # アーキテクチャ設計・フロー図
-    ├── troubleshooting.md       # よくある問題と対処法
-    └── version-strategy.md      # バージョン管理戦略
+└── docs/                    # 📚 Documentation
+    ├── repository-structure.md  # ← This file
+    ├── setup-guide.md           # Detailed setup instructions
+    ├── architecture.md          # Architecture design & diagrams
+    ├── roadmap.md               # Project roadmap
+    ├── version-strategy.md      # Version pinning policy
+    └── troubleshooting.md       # Common issues & fixes
 ```
 
-## コンポーネント関係図
+## Component Relationships
 
 ```mermaid
 graph TB
-    subgraph "ユーザー操作"
-        USER["エンジニア / AI Agent"]
+    subgraph "User Interaction"
+        USER["Engineer / AI Agent"]
     end
 
     subgraph "samples/"
@@ -109,11 +110,11 @@ graph TB
     CONF --> FRR & VJUNOS
 ```
 
-## 新しいベンダーを追加するとき
+## Adding a New Vendor
 
-1. `vendors/<vendor>/parser.py` を作成
-2. `vendors/<vendor>/templates/` にテンプレート追加
-3. `mcp-bridge/src/mcp_bridge/tools/<vendor>.py` にツール実装
-4. `server.py` にツール登録
-5. `labs/` に対応トポロジを追加
-6. `samples/` に使用例を追加
+1. Create `vendors/<vendor>/parser.py`
+2. Add templates in `vendors/<vendor>/templates/`
+3. Implement tools in `mcp-bridge/src/mcp_bridge/tools/<vendor>.py`
+4. Register tools in `server.py`
+5. Add a corresponding topology in `labs/`
+6. Add usage examples in `samples/`

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,10 +1,10 @@
-# 🗺 Roadmap - Clab AI Orchestrator
+# 🗺 Roadmap
 
-プロジェクトの中長期ロードマップ。`agent.md` の5つの Core Objectives を段階的に達成する。
+Project roadmap. Incrementally achieving the 5 Core Objectives defined in `agent.md`.
 
 ---
 
-## 現在地
+## Status
 
 ```mermaid
 gantt
@@ -13,170 +13,170 @@ gantt
     axisFormat %Y-%m
 
     section Phase 0: Foundation
-    リポジトリ構造・基本ラボ・mcp-bridge skeleton    :done, p0, 2026-02, 2026-02
+    Repo structure, basic lab, mcp-bridge skeleton     :done, p0, 2026-02, 2026-02
 
-    section Phase 1: 動くラボ
-    desktop セットアップ・ラボデプロイ・BGP確認       :active, p1, 2026-02, 2026-03
-    Open WebUI + mcp-bridge 連携                     :p1b, 2026-03, 2026-03
+    section Phase 1: Working Lab
+    Server setup, lab deploy, BGP verify               :active, p1, 2026-02, 2026-03
+    Open WebUI + mcp-bridge integration                :p1b, 2026-03, 2026-03
 
-    section Phase 2: AI Troubleshoot
-    自律調査ワークフロー                              :p2, 2026-03, 2026-04
-    エビデンス自動生成                                :p2b, 2026-04, 2026-05
+    section Phase 2: AI Troubleshooting
+    Autonomous investigation workflow                   :p2, 2026-03, 2026-04
+    Automated evidence generation                      :p2b, 2026-04, 2026-05
 
-    section Phase 3: 拡張
-    マルチベンダー・大規模トポロジ                     :p3, 2026-05, 2026-07
-    手順書検証・NETCONF                              :p3b, 2026-06, 2026-08
+    section Phase 3: Expansion
+    Multi-vendor, large topologies                     :p3, 2026-05, 2026-07
+    Runbook validation, NETCONF                        :p3b, 2026-06, 2026-08
 
-    section Phase 4: OSS公開
-    ドキュメント整備・CI/CD                           :p4, 2026-07, 2026-09
+    section Phase 4: OSS Release
+    Documentation, CI/CD                               :p4, 2026-07, 2026-09
 ```
 
 ---
 
-## Phase 0: Foundation ✅ 完了
+## Phase 0: Foundation ✅ Done
 
-> リポジトリの骨格を作り、最小構成のラボを定義する。
+> Build the repository skeleton and define the minimal lab.
 
-| 成果物 | 状態 |
-|--------|------|
-| リポジトリ構造 (labs/, mcp-bridge/, vendors/, docs/, samples/) | ✅ |
-| basic-bgp トポロジ (FRR + vJunos P2P BGP) | ✅ |
-| mcp-bridge skeleton (Python, STDIO, 7ツール) | ✅ |
-| Dockerfile + requirements.lock (バージョン固定) | ✅ |
-| docs (setup-guide, architecture, troubleshooting, version-strategy) | ✅ |
-| samples 3シナリオ | ✅ |
-
----
-
-## Phase 1: 動くラボ 🔧 進行中
-
-> ラボサーバで実際にラボを動かし、MCP 経由で操作できる状態にする。
-
-### 1.1 環境セットアップ
-- [ ] ラボサーバに git clone
-- [ ] `sudo bash setup/install.sh` 実行
-- [ ] vrnetlab で vJunos Docker イメージをビルド
-- [ ] `sudo clab deploy` で basic-bgp ラボ起動
-- [ ] BGP Established 確認
-
-### 1.2 mcp-bridge 実動
-- [ ] mcp-bridge の pip install & 起動テスト
-- [ ] 各ツール (clab_inspect, frr_show, junos_show) の動作検証
-- [ ] Docker コンテナ実行 (`docker compose up`) の検証
-
-### 1.3 Open WebUI 連携
-- [ ] Open WebUI を desktop にデプロイ
-- [ ] MCP サーバとして mcp-bridge を登録
-- [ ] Open WebUI から自然言語で「BGP の状態を見せて」→結果が返ることを確認
-
-### 🏁 Phase 1 完了基準
-- [ ] Open WebUI 上で「ラボをデプロイして BGP 状態を確認」が一気通貫で動く
+| Deliverable | Status |
+|-------------|--------|
+| Repository structure (labs/, mcp-bridge/, vendors/, docs/, samples/) | ✅ |
+| basic-bgp topology (FRR + vJunos P2P BGP) | ✅ |
+| mcp-bridge skeleton (Python, STDIO, 7 tools) | ✅ |
+| Dockerfile + requirements.lock (version pinning) | ✅ |
+| Documentation (setup-guide, architecture, troubleshooting, version-strategy) | ✅ |
+| 3 sample scenarios | ✅ |
 
 ---
 
-## Phase 2: AI 駆動型トラブルシューティング
+## Phase 1: Working Lab 🔧 In Progress
 
-> AI エージェントが自律的に障害を調査・修復できるようにする。
+> Deploy and operate a real lab on the server via MCP.
 
-### 2.1 自律調査ワークフロー
-- [ ] Plan → Act → Reflect → Document パターンの実装
-- [ ] 調査ロジック: L1→L2→L3→BGP の段階的チェック
-- [ ] `agent.md` のワークフロー定義を mcp-bridge の prompt に組込み
-- [ ] samples/02 のシナリオを自動実行できることを確認
+### 1.1 Environment Setup
+- [ ] Clone repo to lab server
+- [ ] Run `sudo bash setup/install.sh`
+- [ ] Build vJunos Docker image via vrnetlab
+- [ ] Deploy basic-bgp lab with `sudo clab deploy`
+- [ ] Verify BGP Established
 
-### 2.2 パーサの拡充
-- [ ] FRR: `show ip bgp neighbor`, `show ip ospf neighbor`, `show interface` パーサ追加
-- [ ] Junos: `show bgp neighbor`, `show ospf neighbor`, `show interfaces` パーサ追加
-- [ ] 異常検出ロジック（State が Established でない場合のアラート等）
+### 1.2 mcp-bridge Validation
+- [ ] Install and start mcp-bridge
+- [ ] Test each tool (clab_inspect, frr_show, junos_show)
+- [ ] Test Docker container execution (`docker compose up`)
 
-### 2.3 エビデンス自動生成
-- [ ] 検証結果を Markdown レポートとして自動出力
-- [ ] トポロジ図の Mermaid 自動生成 (topology.clab.yml → Mermaid)
-- [ ] Before/After 差分レポート
+### 1.3 Open WebUI Integration
+- [ ] Deploy Open WebUI on lab server
+- [ ] Register mcp-bridge as MCP server
+- [ ] Verify natural language → MCP tool invocation works
 
-### 🏁 Phase 2 完了基準
-- [ ] AI に「BGP が落ちているので調査して」と言えば、自律的に原因特定→修復→レポート出力
-
----
-
-## Phase 3: 拡張
-
-> 対応ベンダー・プロトコル・トポロジ規模を拡張する。
-
-### 3.1 プロトコル拡張
-- [ ] OSPF ラボ (FRR + vJunos)
-- [ ] BGP + OSPF 混在ラボ (IGP/EGP 連携)
-- [ ] BFD 連携
-- [ ] IS-IS ラボ
-
-### 3.2 トポロジスケール
-- [ ] 4ノード構成 (FRR×2 + vJunos×2, フルメッシュ/ハブスポーク)
-- [ ] トポロジテンプレート: ユーザーがパラメータ指定で any 構成を生成
-- [ ] labs/ ジェネレータツール
-
-### 3.3 新ベンダー対応
-- [ ] Arista cEOS 対応 (eAPI パーサ + テンプレート)
-- [ ] Nokia SR Linux 対応
-- [ ] vendors/ プラグインアーキテクチャの整備
-
-### 3.4 高度な機能
-- [ ] NETCONF/YANG 対応 (ncclient / PyEZ)
-- [ ] 手順書検証: Markdown 手順書 ↔ 実機状態の自動比較
-- [ ] 設定ドリフト検出
-
-### 3.5 MCP 通信拡張
-- [ ] HTTP+SSE トランスポート追加 (Mac からリモート操作)
-- [ ] 認証・認可
-
-### 🏁 Phase 3 完了基準
-- [ ] 3ベンダー以上、2プロトコル以上のラボが動作
-- [ ] 手順書を渡すと AIが矛盾を指摘できる
+### 🏁 Phase 1 Completion Criteria
+- [ ] "Deploy lab and check BGP status" works end-to-end via Open WebUI
 
 ---
 
-## Phase 4: OSS 公開
+## Phase 2: AI-Driven Troubleshooting
 
-> GitHub パブリックリポジトリとして公開し、コミュニティに貢献する。
+> Enable autonomous fault investigation and repair by AI agents.
 
-### 4.1 品質整備
-- [ ] pytest による自動テスト (パーサ、テンプレート)
+### 2.1 Autonomous Investigation Workflow
+- [ ] Implement Plan → Act → Reflect → Document pattern
+- [ ] Investigation logic: L1 → L2 → L3 → BGP staged checks
+- [ ] Embed `agent.md` workflow into mcp-bridge prompts
+- [ ] Verify samples/02 scenario runs autonomously
+
+### 2.2 Parser Expansion
+- [ ] FRR: `show ip bgp neighbor`, `show ip ospf neighbor`, `show interface` parsers
+- [ ] Junos: `show bgp neighbor`, `show ospf neighbor`, `show interfaces` parsers
+- [ ] Anomaly detection logic (alert when state ≠ Established, etc.)
+
+### 2.3 Automated Evidence Generation
+- [ ] Auto-generate verification reports as Markdown
+- [ ] Auto-generate Mermaid topology diagrams from topology.clab.yml
+- [ ] Before/After diff reports
+
+### 🏁 Phase 2 Completion Criteria
+- [ ] AI autonomously identifies root cause → repairs → generates report
+
+---
+
+## Phase 3: Expansion
+
+> Expand vendor support, protocols, and topology scale.
+
+### 3.1 Protocol Expansion
+- [ ] OSPF lab (FRR + vJunos)
+- [ ] BGP + OSPF combined lab (IGP/EGP interplay)
+- [ ] BFD integration
+- [ ] IS-IS lab
+
+### 3.2 Topology Scale
+- [ ] 4-node topology (FRR×2 + vJunos×2, full-mesh / hub-spoke)
+- [ ] Topology templates: generate any topology from parameters
+- [ ] Labs generator tool
+
+### 3.3 New Vendor Support
+- [ ] Arista cEOS (eAPI parser + templates)
+- [ ] Nokia SR Linux
+- [ ] Plugin architecture for `vendors/`
+
+### 3.4 Advanced Features
+- [ ] NETCONF/YANG support (ncclient / PyEZ)
+- [ ] Runbook validation: auto-compare Markdown runbooks ↔ live state
+- [ ] Configuration drift detection
+
+### 3.5 MCP Transport Expansion
+- [ ] Add HTTP+SSE transport (remote operation from Mac)
+- [ ] Authentication & authorization
+
+### 🏁 Phase 3 Completion Criteria
+- [ ] 3+ vendors, 2+ protocols working
+- [ ] AI can identify contradictions in runbooks
+
+---
+
+## Phase 4: OSS Release
+
+> Publish as a public GitHub repository and engage the community.
+
+### 4.1 Quality
+- [ ] pytest-based automated tests (parsers, templates)
 - [ ] GitHub Actions CI/CD (lint, test, Docker build)
 - [ ] pre-commit hooks (ruff, mypy)
 
-### 4.2 ドキュメント整備
-- [ ] Contributing Guide (CONTRIBUTING.md)
+### 4.2 Community
+- [ ] CONTRIBUTING.md
 - [ ] Code of Conduct
-- [ ] Issue / PR テンプレート
-- [ ] デモ動画 / GIF (Open WebUI + mcp-bridge のライブデモ)
+- [ ] Issue / PR templates
+- [ ] Demo video / GIF (Open WebUI + mcp-bridge live demo)
 
-### 4.3 パッケージング
-- [ ] PyPI 公開 (`pip install mcp-bridge`)
-- [ ] Docker Hub / ghcr.io にイメージ公開
+### 4.3 Packaging
+- [ ] PyPI publish (`pip install mcp-bridge`)
+- [ ] Docker Hub / ghcr.io image publish
 - [ ] GitHub Releases + Changelog
 
-### 🏁 Phase 4 完了基準
-- [ ] 他のエンジニアが README だけで環境構築→ラボ起動→AI操作できる
+### 🏁 Phase 4 Completion Criteria
+- [ ] Anyone can set up → deploy lab → AI-operate using only the README
 - [ ] GitHub Stars ≥ 10 🌟
 
 ---
 
-## 優先度マトリクス
+## Priority Matrix
 
 ```mermaid
 quadrantChart
-    title 機能の優先度 vs 難易度
-    x-axis 低難易度 --> 高難易度
-    y-axis 低優先度 --> 高優先度
+    title Feature Priority vs Difficulty
+    x-axis Low Difficulty --> High Difficulty
+    y-axis Low Priority --> High Priority
 
-    Phase 1 ラボ起動: [0.2, 0.9]
-    Open WebUI 連携: [0.3, 0.85]
-    自律調査ワークフロー: [0.5, 0.8]
-    エビデンス自動生成: [0.4, 0.7]
-    パーサ拡充: [0.3, 0.6]
-    OSPF ラボ: [0.3, 0.5]
-    新ベンダー対応: [0.5, 0.4]
+    Phase 1 Lab Deploy: [0.2, 0.9]
+    Open WebUI Integration: [0.3, 0.85]
+    Autonomous Investigation: [0.5, 0.8]
+    Evidence Generation: [0.4, 0.7]
+    Parser Expansion: [0.3, 0.6]
+    OSPF Lab: [0.3, 0.5]
+    New Vendor Support: [0.5, 0.4]
     NETCONF/YANG: [0.7, 0.5]
-    手順書検証: [0.8, 0.6]
+    Runbook Validation: [0.8, 0.6]
     CI/CD: [0.4, 0.3]
-    PyPI 公開: [0.5, 0.2]
+    PyPI Publish: [0.5, 0.2]
 ```

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -1,40 +1,40 @@
-# セットアップガイド
+# Setup Guide
 
-Ubuntu 24.04 での環境構築手順。
+Environment setup on Ubuntu 24.04.
 
-## 前提条件
+## Prerequisites
 
 - Ubuntu 24.04 LTS
-- sudo 権限
-- インターネット接続
-- vJunos-router QCOW2 イメージ
+- sudo privileges
+- Internet connection
+- vJunos-router QCOW2 image
 
-## 自動セットアップ
+## Automated Setup
 
 ```bash
 sudo bash setup/install.sh
 ```
 
-このスクリプトは以下をインストールします:
-1. **Docker** - コンテナ実行環境
-2. **containerlab** - ネットワークラボオーケストレータ
-3. **FRR イメージ** - `quay.io/frrouting/frr:10.3.1`
-4. **vrnetlab** - vJunos QCOW2 → Docker イメージ変換
-5. **Python 3** - mcp-bridge 実行環境
+This script installs:
+1. **Docker** — Container runtime
+2. **containerlab** — Network lab orchestrator
+3. **FRR image** — `quay.io/frrouting/frr:10.3.1`
+4. **vrnetlab** — Converts vJunos QCOW2 → Docker image
+5. **Python 3** — Runtime for mcp-bridge
 
-## vJunos-router イメージの準備
+## Preparing the vJunos-router Image
 
-### 1. ダウンロード
-[Juniper サポートサイト](https://support.juniper.net/) から `vJunos-router-*.qcow2` をダウンロード。
+### 1. Download
+Download `vJunos-router-*.qcow2` from [Juniper Support](https://support.juniper.net/).
 
-### 2. 配置
+### 2. Place
 ```bash
 cp vJunos-router-25.4R1.12.qcow2 images/
 ```
 
-### 3. Docker イメージビルド
-`setup/install.sh` を実行すると自動で vrnetlab によるビルドが行われます。  
-手動で行う場合:
+### 3. Build Docker Image
+Running `setup/install.sh` will automatically build via vrnetlab.  
+To build manually:
 
 ```bash
 cp images/vJunos-router-25.4R1.12.qcow2 /opt/vrnetlab/vjunos-router/
@@ -42,13 +42,13 @@ cd /opt/vrnetlab/vjunos-router
 sudo make
 ```
 
-### 4. 確認
+### 4. Verify
 ```bash
 docker images | grep vjunos
 # vrnetlab/vr-vjunos   25.4R1.12   ...
 ```
 
-## mcp-bridge のセットアップ
+## Setting Up mcp-bridge
 
 ```bash
 cd mcp-bridge
@@ -57,16 +57,16 @@ source .venv/bin/activate
 pip install -e ".[dev]"
 ```
 
-## 動作確認
+## Smoke Test
 
 ```bash
-# ラボデプロイ
+# Deploy lab
 sudo clab deploy -t labs/basic-bgp/topology.clab.yml
 
-# ノード確認
+# Inspect nodes
 sudo clab inspect -t labs/basic-bgp/topology.clab.yml
 
-# BGP 確認
+# Check BGP
 docker exec clab-basic-bgp-frr1 vtysh -c "show ip bgp summary"
 docker exec clab-basic-bgp-vjunos1 cli show bgp summary
 ```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,51 +1,51 @@
-# トラブルシューティング
+# Troubleshooting
 
-## containerlab 関連
+## containerlab
 
-### `clab deploy` が失敗する
+### `clab deploy` fails
 
-**症状**: Permission denied エラー
+**Symptom**: Permission denied error
 
 ```bash
-# sudo で実行する
+# Run with sudo
 sudo clab deploy -t labs/basic-bgp/topology.clab.yml
 ```
 
-### vJunos ノードが起動しない
+### vJunos node doesn't start
 
-**症状**: `clab inspect` でノードが `running` にならない
+**Symptom**: Node not showing `running` in `clab inspect`
 
-1. Docker イメージの確認:
+1. Check Docker image:
 ```bash
 docker images | grep vjunos
 ```
 
-2. イメージが無い場合は vrnetlab でビルド:
+2. If image is missing, build with vrnetlab:
 ```bash
 cp images/vJunos-router-25.4R1.12.qcow2 /opt/vrnetlab/vjunos-router/
 cd /opt/vrnetlab/vjunos-router && sudo make
 ```
 
-3. vJunos は起動に **3〜5分** かかる場合があります。しばらく待ってから再確認してください。
+3. vJunos may take **3–5 minutes** to boot. Wait and re-check.
 
-### ラボが残っている
+### Stale lab remains
 
 ```bash
-# 状態確認
+# Check all labs
 sudo clab inspect --all
 
-# 特定ラボの破棄
+# Destroy specific lab
 sudo clab destroy -t labs/basic-bgp/topology.clab.yml
 
-# クリーンアップ付き
+# Destroy with cleanup
 sudo clab destroy -t labs/basic-bgp/topology.clab.yml --cleanup
 ```
 
-## BGP 関連
+## BGP
 
-### BGP ネイバーが Established にならない
+### BGP neighbor not establishing
 
-1. **IP アドレス確認**:
+1. **Check IP addresses**:
 ```bash
 # FRR
 docker exec clab-basic-bgp-frr1 vtysh -c "show interface brief"
@@ -54,12 +54,12 @@ docker exec clab-basic-bgp-frr1 vtysh -c "show interface brief"
 docker exec clab-basic-bgp-vjunos1 cli show interfaces terse
 ```
 
-2. **疎通確認**:
+2. **Check reachability**:
 ```bash
 docker exec clab-basic-bgp-frr1 ping -c 3 192.0.2.2
 ```
 
-3. **BGP 詳細ログ**:
+3. **Check BGP details**:
 ```bash
 # FRR
 docker exec clab-basic-bgp-frr1 vtysh -c "show ip bgp neighbor 192.0.2.2"
@@ -68,9 +68,9 @@ docker exec clab-basic-bgp-frr1 vtysh -c "show ip bgp neighbor 192.0.2.2"
 docker exec clab-basic-bgp-vjunos1 cli show bgp neighbor 192.0.2.1
 ```
 
-## mcp-bridge 関連
+## mcp-bridge
 
-### インストールエラー
+### Installation error
 
 ```bash
 cd mcp-bridge
@@ -79,10 +79,10 @@ source .venv/bin/activate
 pip install -e ".[dev]"
 ```
 
-### MCP サーバが起動しない
+### MCP server won't start
 
-- Python 3.10 以上が必要です
-- `mcp` パッケージが正しくインストールされているか確認:
+- Requires Python 3.10+
+- Verify `mcp` package is installed:
 ```bash
 pip show mcp
 ```

--- a/docs/version-strategy.md
+++ b/docs/version-strategy.md
@@ -1,36 +1,36 @@
-# バージョン管理戦略
+# Version Strategy
 
-本プロジェクトで使用するツール・ライブラリのバージョン固定方針。
+Version pinning policy for tools and libraries used in this project.
 
-## 方針
+## Policy
 
-| レイヤー | 方式 | 理由 |
-|---------|------|------|
-| **Python ランタイム** | Dockerfile で固定 (`3.12.8`) | OS の Python に依存しない |
-| **Python パッケージ** | `requirements.lock` で全ピン | 再現可能なビルド |
-| **containerlab** | setup スクリプトで最新安定版 | 破壊的変更が少ない |
-| **FRR イメージ** | `.env.example` でタグ固定 (`10.3.1`) | NOS バージョンは検証済みのものを使用 |
-| **vJunos イメージ** | vrnetlab ビルド時に固定 (`25.4R1.12`) | イメージ単位で管理 |
+| Layer | Method | Rationale |
+|-------|--------|-----------|
+| **Python runtime** | Pinned in Dockerfile (`3.12.8`) | Independent of host Python |
+| **Python packages** | Fully pinned in `requirements.lock` | Reproducible builds |
+| **containerlab** | Latest stable via setup script | Rarely has breaking changes |
+| **FRR image** | Tag pinned in `.env.example` (`10.3.1`) | Use verified NOS versions |
+| **vJunos image** | Pinned at vrnetlab build time (`25.4R1.12`) | Managed per-image |
 
-## mcp-bridge: ネイティブ vs コンテナ
+## mcp-bridge: Native vs Container
 
-### コンテナ実行（推奨）
+### Container Execution (Recommended)
 
 ```bash
 docker compose up -d
 ```
 
-**メリット:**
-- Python バージョン・依存関係が完全に分離される
-- ホスト環境を汚さない
-- Docker socket マウントで containerlab 操作も可能
-- 本番環境とテスト環境で同一イメージが使える
+**Advantages:**
+- Python version and dependencies are fully isolated
+- Does not pollute the host environment
+- Docker socket mount enables containerlab operations
+- Same image for production and test environments
 
-**注意:**
-- Docker socket を Read-Only でマウント → セキュリティ面の考慮
-- STDIO 通信は `stdin_open: true` + `tty: true` で確保
+**Notes:**
+- Docker socket is mounted read-only for security
+- STDIO communication is preserved via `stdin_open: true` + `tty: true`
 
-### ネイティブ実行（開発時）
+### Native Execution (Development)
 
 ```bash
 cd mcp-bridge
@@ -41,27 +41,27 @@ pip install -e ".[dev]"
 mcp-bridge
 ```
 
-開発中の素早いイテレーションにはネイティブ実行が便利。
+Native execution is convenient for rapid iteration during development.
 
-## バージョン更新手順
+## Updating Versions
 
-### Python パッケージの更新
+### Python Packages
 
 ```bash
 cd mcp-bridge
-# 1. pyproject.toml の依存を編集
-# 2. ロックファイルを再生成
+# 1. Edit dependencies in pyproject.toml
+# 2. Regenerate lock file
 pip install pip-tools
 pip-compile pyproject.toml -o requirements.lock
-# 3. テスト
+# 3. Test
 pip install -r requirements.lock
 pytest
-# 4. Docker イメージを再ビルド
+# 4. Rebuild Docker image
 docker compose build
 ```
 
-### FRR / vJunos イメージの更新
+### FRR / vJunos Images
 
-1. `.env.example` のバージョンタグを変更
-2. `labs/` のトポロジ定義を新バージョンに合わせて更新
-3. `samples/` で動作確認
+1. Update version tags in `.env.example`
+2. Update topology definitions in `labs/` for the new version
+3. Verify with `samples/`

--- a/labs/README.md
+++ b/labs/README.md
@@ -1,11 +1,11 @@
 # Labs
 
-containerlab トポロジ定義と初期設定ファイル。
+Containerlab topology definitions and initial configuration files.
 
-## 利用可能なラボ
+## Available Labs
 
 ### basic-bgp
-FRR + vJunos-router の最小 eBGP 構成。
+Minimal eBGP topology with FRR + vJunos-router.
 
 ```
 FRR1 (AS65001, 192.0.2.1/30) ---- P2P ---- vJunos1 (AS65002, 192.0.2.2/30)
@@ -13,12 +13,12 @@ FRR1 (AS65001, 192.0.2.1/30) ---- P2P ---- vJunos1 (AS65002, 192.0.2.2/30)
 ```
 
 ```bash
-# デプロイ
+# Deploy
 sudo clab deploy -t labs/basic-bgp/topology.clab.yml
 
-# 確認
+# Inspect
 sudo clab inspect -t labs/basic-bgp/topology.clab.yml
 
-# 破棄
+# Destroy
 sudo clab destroy -t labs/basic-bgp/topology.clab.yml
 ```

--- a/mcp-bridge/README.md
+++ b/mcp-bridge/README.md
@@ -1,8 +1,8 @@
 # MCP Bridge
 
-containerlab / FRR / vJunos-router を操作するための MCP (Model Context Protocol) サーバ。
+MCP (Model Context Protocol) server for operating containerlab / FRR / vJunos-router.
 
-## セットアップ
+## Setup
 
 ```bash
 python3 -m venv .venv
@@ -10,31 +10,31 @@ source .venv/bin/activate
 pip install -e ".[dev]"
 ```
 
-## 起動
+## Run
 
 ```bash
-# STDIO モード
+# STDIO mode
 mcp-bridge
 ```
 
-## 提供ツール
+## Available Tools
 
-| ツール | 説明 |
-|--------|------|
-| `clab_deploy` | containerlab トポロジをデプロイ |
-| `clab_destroy` | トポロジを破棄 |
-| `clab_inspect` | ノード状態を確認 |
-| `frr_show` | FRR で show コマンドを実行 |
-| `frr_config` | FRR に設定を投入 |
-| `junos_show` | vJunos で show コマンドを実行 |
-| `junos_config` | vJunos に設定を投入 |
+| Tool | Description |
+|------|-------------|
+| `clab_deploy` | Deploy a containerlab topology |
+| `clab_destroy` | Destroy a topology |
+| `clab_inspect` | Inspect node status |
+| `frr_show` | Execute show commands on FRR |
+| `frr_config` | Push configuration to FRR |
+| `junos_show` | Execute show commands on vJunos |
+| `junos_config` | Push configuration to vJunos |
 
-## 開発
+## Development
 
 ```bash
-# lint
+# Lint
 ruff check src/
 
-# テスト
+# Test
 pytest
 ```

--- a/samples/02_troubleshoot_bgp/README.md
+++ b/samples/02_troubleshoot_bgp/README.md
@@ -1,30 +1,29 @@
 # Sample 02: Troubleshoot BGP
 
-BGP ピアリングが確立しない障害を調査し、修復するシナリオ。
+Investigate and repair a BGP peering failure.
 
-## シナリオ概要
+## Scenario
 
-FRR1 の BGP ネイバー設定を意図的に間違え、障害を発生させた後、
-AIエージェント（または手動）で原因を特定し修復します。
+Intentionally misconfigure FRR1's BGP neighbor, then use AI agents (or manual steps) to identify the root cause and repair it.
 
 ```mermaid
 flowchart TD
-    A["🔴 BGP Down"] --> B["1. 症状確認"]
-    B --> C["2. L1/L2 確認: 物理接続OK?"]
-    C --> D["3. L3 確認: IP reachability OK?"]
-    D --> E["4. BGP 確認: ネイバー設定は正しい?"]
-    E --> F["5. 原因特定: AS番号ミス"]
-    F --> G["6. 修復: 正しいAS番号に変更"]
+    A["🔴 BGP Down"] --> B["1. Check symptoms"]
+    B --> C["2. L1/L2: Physical connectivity OK?"]
+    C --> D["3. L3: IP reachability OK?"]
+    D --> E["4. BGP: Neighbor config correct?"]
+    E --> F["5. Root cause: AS number mismatch"]
+    F --> G["6. Fix: Correct the AS number"]
     G --> H["🟢 BGP Established"]
 ```
 
-## 手順
+## Steps
 
-### Step 1: 障害を発生させる
+### Step 1: Inject the Fault
 
-FRR1 のネイバー設定で **間違った**リモートAS番号を設定する。
+Set an **incorrect** remote AS number on FRR1.
 
-**MCP ツール:**
+**MCP Tool:**
 ```json
 {
   "tool": "frr_config",
@@ -39,16 +38,7 @@ FRR1 のネイバー設定で **間違った**リモートAS番号を設定す�
 }
 ```
 
-**手動 CLI:**
-```bash
-docker exec clab-basic-bgp-frr1 vtysh -c "conf t" \
-  -c "router bgp 65001" \
-  -c "no neighbor 192.0.2.2 remote-as 65002" \
-  -c "neighbor 192.0.2.2 remote-as 65099" \
-  -c "end"
-```
-
-### Step 2: 症状を確認
+### Step 2: Observe the Symptom
 
 ```json
 {
@@ -60,32 +50,32 @@ docker exec clab-basic-bgp-frr1 vtysh -c "conf t" \
 }
 ```
 
-**期待される出力:** State が `OpenSent` / `Active` (Established でない)
+**Expected:** State shows `OpenSent` / `Active` (not Established)
 
-### Step 3: 調査ワークフロー
+### Step 3: Investigation Workflow
 
-AIエージェントが自律的に行う場合の調査フロー:
+When an AI agent investigates autonomously:
 
 ```
 1. frr_show → "show ip bgp summary"
-   → ネイバーが Established でない
+   → Neighbor is NOT Established
 
 2. frr_show → "show ip bgp neighbor 192.0.2.2"
-   → "remote AS 65099" が表示される
-   → "Last error: ...Bad peer AS" が表示される
+   → Shows "remote AS 65099"
+   → Shows "Last error: ...Bad peer AS"
 
 3. junos_show → "show bgp summary"
-   → vJunos 側も Established でない
+   → vJunos side also NOT Established
 
-4. 比較推論:
-   → FRR 側: remote-as 65099
-   → vJunos 側: local-as 65002
-   → ミスマッチが原因と判断
+4. Reasoning:
+   → FRR side: remote-as 65099
+   → vJunos side: local-as 65002
+   → Mismatch identified as root cause
 ```
 
-### Step 4: 修復
+### Step 4: Repair
 
-**MCP ツール:**
+**MCP Tool:**
 ```json
 {
   "tool": "frr_config",
@@ -100,7 +90,7 @@ AIエージェントが自律的に行う場合の調査フロー:
 }
 ```
 
-### Step 5: 復旧確認
+### Step 5: Verify Recovery
 
 ```json
 {
@@ -112,10 +102,10 @@ AIエージェントが自律的に行う場合の調査フロー:
 }
 ```
 
-**期待される出力:** State が `Established` に復旧
+**Expected:** State returns to `Established`
 
-## 学べること
+## What You Learn
 
-- BGP の障害調査フロー（L1→L2→L3→L4）
-- `show ip bgp neighbor` の "Last error" から原因を特定する方法
-- MCP ツール経由での設定変更・自動修復
+- BGP investigation flow (L1 → L2 → L3 → L4)
+- Using `show ip bgp neighbor` "Last error" to identify root cause
+- Automated config repair via MCP tools

--- a/samples/03_config_change/README.md
+++ b/samples/03_config_change/README.md
@@ -1,19 +1,19 @@
 # Sample 03: Config Change
 
-Jinja2 テンプレートを使って設定を生成し、FRR / vJunos に投入するシナリオ。
+Use Jinja2 templates to generate configs, push to FRR/vJunos, and verify propagation.
 
-## シナリオ概要
+## Scenario
 
-既存の BGP 設定に加えて、新しい Loopback ネットワークを追加広告します。
+Add a new loopback network to FRR1's BGP advertisements.
 
 ```
-変更前: FRR1 → 10.0.0.1/32 のみ広告
-変更後: FRR1 → 10.0.0.1/32 + 10.1.0.0/24 を広告
+Before: FRR1 advertises 10.0.0.1/32 only
+After:  FRR1 advertises 10.0.0.1/32 + 10.1.0.0/24
 ```
 
-## 手順
+## Steps
 
-### Step 1: 現在の経路を確認
+### Step 1: Check Current Routes
 
 ```json
 {
@@ -25,17 +25,16 @@ Jinja2 テンプレートを使って設定を生成し、FRR / vJunos に投入
 }
 ```
 
-**期待される出力:** 10.0.0.1/32 のみ
+**Expected:** Only 10.0.0.1/32
 
-### Step 2: テンプレートで設定を生成
+### Step 2: Generate Config from Template
 
 ```python
-# vendors/frr/templates を使った設定生成の例
+# Example using vendors/frr/templates
 from jinja2 import Environment, FileSystemLoader
 
 env = Environment(loader=FileSystemLoader("vendors/frr/templates"))
 
-# 追加ネットワーク用のカスタムテンプレートも作成可能
 config_lines = [
     "router bgp 65001",
     "address-family ipv4 unicast",
@@ -44,9 +43,9 @@ config_lines = [
 ]
 ```
 
-### Step 3: FRR に設定を投入
+### Step 3: Push Config to FRR
 
-**MCP ツール:**
+**MCP Tool:**
 ```json
 {
   "tool": "frr_config",
@@ -65,7 +64,7 @@ config_lines = [
 }
 ```
 
-### Step 4: 広告を確認
+### Step 4: Verify Advertisement
 
 ```json
 {
@@ -77,7 +76,7 @@ config_lines = [
 }
 ```
 
-### Step 5: vJunos 側で受信を確認
+### Step 5: Verify Reception on vJunos
 
 ```json
 {
@@ -89,11 +88,9 @@ config_lines = [
 }
 ```
 
-**期待される出力:** 10.0.0.1/32 + 10.1.0.0/24
+**Expected:** 10.0.0.1/32 + 10.1.0.0/24
 
-### Step 6: ロールバック
-
-設定を元に戻す。
+### Step 6: Rollback
 
 ```json
 {
@@ -113,9 +110,9 @@ config_lines = [
 }
 ```
 
-## 学べること
+## What You Learn
 
-- Jinja2 テンプレートを使った設定生成
-- ネットワーク追加広告の流れ
-- FRR / Junos 間での経路伝搬確認
-- 設定のロールバック方法
+- Using Jinja2 templates for config generation
+- Network advertisement workflow
+- Cross-vendor route propagation verification (FRR ↔ Junos)
+- Configuration rollback

--- a/samples/README.md
+++ b/samples/README.md
@@ -1,22 +1,22 @@
-# Samples - 使用例・シナリオ集
+# Samples — Usage Examples & Scenarios
 
-本ディレクトリには、Clab AI Orchestrator の具体的な使い方をシナリオ別にまとめています。  
-各シナリオは独立しており、順番に実行することでプロジェクトの全機能を体験できます。
+This directory contains concrete usage scenarios for Clab AI Orchestrator.  
+Each scenario is self-contained and can be followed sequentially to experience all features.
 
-## シナリオ一覧
+## Scenario Index
 
-| # | シナリオ | 内容 | 対象ツール |
-|---|---------|------|-----------|
-| 01 | [Deploy & Verify](01_deploy_and_verify/) | ラボの構築から BGP 疎通確認まで | `clab_deploy`, `clab_inspect`, `frr_show`, `junos_show` |
-| 02 | [Troubleshoot BGP](02_troubleshoot_bgp/) | BGP 障害の調査と修復 | `frr_show`, `junos_show`, `frr_config`, `junos_config` |
-| 03 | [Config Change](03_config_change/) | 設定変更とロールバック | `frr_config`, `junos_config`, テンプレート |
+| # | Scenario | Description | Tools Used |
+|---|----------|-------------|------------|
+| 01 | [Deploy & Verify](01_deploy_and_verify/) | Lab deployment → BGP verification | `clab_deploy`, `clab_inspect`, `frr_show`, `junos_show` |
+| 02 | [Troubleshoot BGP](02_troubleshoot_bgp/) | BGP fault investigation & repair | `frr_show`, `junos_show`, `frr_config`, `junos_config` |
+| 03 | [Config Change](03_config_change/) | Configuration change & rollback | `frr_config`, `junos_config`, templates |
 
-## 前提条件
+## Prerequisites
 
-- `sudo clab deploy -t labs/basic-bgp/topology.clab.yml` でラボがデプロイ済み
-- BGP が Established 状態
+- Lab deployed: `sudo clab deploy -t labs/basic-bgp/topology.clab.yml`
+- BGP in Established state
 
-## 使い方
+## How to Use
 
-各シナリオの `README.md` に手順が記載されています。  
-MCP ツール経由（AI エージェント）でも、手動の CLI でも実行できます。
+Each scenario has a `README.md` with step-by-step instructions.  
+They can be executed via MCP tools (AI agent) or manual CLI commands.

--- a/vendors/README.md
+++ b/vendors/README.md
@@ -1,36 +1,36 @@
 # Vendors
 
-ベンダー固有のパーサと設定テンプレートを格納するモジュール。
+Vendor-specific parsers and configuration templates.
 
-## 構造
+## Structure
 
 ```
 vendors/
 ├── frr/
-│   ├── parser.py          # FRR show コマンド出力パーサ
+│   ├── parser.py          # FRR show command output parser
 │   └── templates/
-│       └── bgp.conf.j2    # BGP 設定テンプレート
+│       └── bgp.conf.j2    # BGP config template
 └── junos/
-    ├── parser.py          # Junos show コマンド出力パーサ
+    ├── parser.py          # Junos show command output parser
     └── templates/
-        └── bgp.conf.j2    # BGP 設定テンプレート
+        └── bgp.conf.j2    # BGP config template
 ```
 
-## パーサ
+## Parsers
 
 ### FRR (`frr/parser.py`)
-- `parse_bgp_summary()` - `show ip bgp summary` の出力を構造化
-- `parse_ip_route()` - `show ip route` の出力を構造化
+- `parse_bgp_summary()` — Parses `show ip bgp summary` into structured data
+- `parse_ip_route()` — Parses `show ip route` into structured data
 
 ### Junos (`junos/parser.py`)
-- `parse_bgp_summary()` - `show bgp summary` の出力を構造化 (text/JSON)
-- `parse_route_table()` - `show route` の出力を構造化
+- `parse_bgp_summary()` — Parses `show bgp summary` (text/JSON) into structured data
+- `parse_route_table()` — Parses `show route` into structured data
 
-## テンプレート
+## Templates
 
-Jinja2 形式の設定テンプレート。新しいラボ構成を作成する際に使用。
+Jinja2-format configuration templates for generating new lab configs.
 
-### 使用例
+### Usage Example
 ```python
 from jinja2 import Environment, FileSystemLoader
 
@@ -48,9 +48,9 @@ config = template.render(
 )
 ```
 
-## 新しいベンダーの追加
+## Adding a New Vendor
 
-1. `vendors/<vendor_name>/` ディレクトリを作成
-2. `parser.py` に show コマンドパーサを実装
-3. `templates/` に Jinja2 テンプレートを追加
-4. `mcp-bridge/src/mcp_bridge/tools/` に対応ツールを追加
+1. Create `vendors/<vendor_name>/` directory
+2. Implement `parser.py` with show command parsers
+3. Add Jinja2 templates in `templates/`
+4. Add corresponding tools in `mcp-bridge/src/mcp_bridge/tools/`


### PR DESCRIPTION
## Changes

- **All documentation converted from Japanese to English** (16 files)
  - README.md, agent.md, all docs/*.md, samples/**/README.md, vendors/README.md, mcp-bridge/README.md, labs/README.md
- **README architecture diagram generalized**
  - Removed specific FRR/vJunos references from the diagram
  - Emphasizes support for any containerlab topology (multi-vendor, multi-protocol)
- **Added PR workflow** (.agent/workflows/pr.md)

## Language Policy
- Repository contents (docs, code comments): **English**
- Contributor conversations: any language

## Security
- Confirmed: no Japanese hostnames, Tailscale URLs, or personal info remain